### PR TITLE
Changes required to publish staging packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,18 @@ It is possible for Cannon to verify freshly deployed contracts, using the follow
 `./run pnpm cannon verify infinex-multichain:VERSION -c CHAIN_ID --api-key ETHERSCAN_KEY`
 
 
+## useful commands
+ ```
+  CANNON_REGISTRY_PRIORITY=local pnpm cannon alter --chain-id 421614  --subpkg clone.infinex infinex-multichain:0.1.7@O2 mark-complete deploy.Forwarder deploy.AccountFactory invoke.AccountFactoryInitialize deploy.InitialProxyImplementation
+  ```
+   generates an IPFS url that can be upgraded from if steps are executing that shouldn't. Cannon checks and redeploys a contract if the bytecode has changed, which can be for many reasons, including a different compiler version.
+
+   e.g. upgrade to function would reference the generated ipfs url 
+
+```
+ CANNON_REGISTRY_PRIORITY=local pnpm cannon build infinex-multichain/testnet/infinex-multichain-arbitrum-sepolia.toml --chain-id 421614 --private-key  XXXX --upgrade-from @ipfs:QmcU78qLgucSaPerrJqYEaanMCNVZhZbBgSiyGgcyvcpy3
+```
+
+also, when publishing, adding ` --tags 1.0.0` ensures that a package only gets published with the specified space separated tags, and not default which includes latest
 
 

--- a/infinex-multichain/staging/infinex-multichain-apps-arbitrum.toml
+++ b/infinex-multichain/staging/infinex-multichain-apps-arbitrum.toml
@@ -1,5 +1,5 @@
 name = "infinex-multichain"
-version = "1.0.0"
+version = "1.0.0staging"
 preset = "apps"
 description = "Infinex App integrations"
 #    pnpm cannon build infinex-multichain/testnets/infinex-multichain-apps-arbitrum.toml --chain-id 42161 --private-key 
@@ -14,7 +14,8 @@ options.APPS_USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
 # Curve Stableswap Config
 options.APPS_CRV_CURVE_STABLESWAP_FACTORY = "0x9AF14D26075f142eb3F292D5065EB3faa646167b" 
 source = "infinex:1.0.0@apps"
-target = "infinex:1.0.0@apps"
+target = "infinex:1.0.0staging@apps"
+tags = ["1.0.0staging"]
 
 
 

--- a/infinex-multichain/staging/infinex-multichain-apps-base.toml
+++ b/infinex-multichain/staging/infinex-multichain-apps-base.toml
@@ -1,5 +1,5 @@
 name = "infinex-multichain"
-version = "1.0.0"
+version = "1.0.0staging"
 preset = "apps"
 description = "Infinex App integrations"
 #   pnpm cannon build infinex-multichain/staging/infinex-multichain-apps-base.toml --chain-id 8453 --private-key 
@@ -14,7 +14,8 @@ options.APPS_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
 # Curve Stableswap Config
 options.APPS_CRV_CURVE_STABLESWAP_FACTORY = "0xd2002373543Ce3527023C75e7518C274A51ce712" 
 source = "infinex:1.0.0@apps"
-target = "infinex:1.0.0@apps"
+target = "infinex:1.0.0staging@apps"
+tags = ["1.0.0staging"]
 
 # invoke the transfer of ownership from the deployer to the multisig
 

--- a/infinex-multichain/staging/infinex-multichain-apps-ethereum.toml
+++ b/infinex-multichain/staging/infinex-multichain-apps-ethereum.toml
@@ -1,5 +1,5 @@
 name = "infinex-multichain"
-version = "1.0.0"
+version = "1.0.0staging"
 preset = "apps"
 description = "Infinex App integrations"
 #  pnpm cannon build infinex-multichain/staging/infinex-multichain-apps-ethereum.toml --chain-id 1 --private-key
@@ -15,4 +15,5 @@ options.APPS_USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
 # Curve Stableswap Config
 options.APPS_CRV_CURVE_STABLESWAP_FACTORY = "0x6A8cbed756804B16E05E741eDaBd5cB544AE21bf" 
 source = "infinex:1.0.0@apps"
-target = "infinex:1.0.0@apps"
+target = "infinex:1.0.0staging@apps"
+tags = ["1.0.0staging"]

--- a/infinex-multichain/staging/infinex-multichain-apps-optimism.toml
+++ b/infinex-multichain/staging/infinex-multichain-apps-optimism.toml
@@ -1,5 +1,5 @@
 name = "infinex-multichain"
-version = "1.0.0"
+version = "1.0.0staging"
 preset = "apps"
 description = "Infinex App integrations"
 #   pnpm cannon build infinex-multichain/staging/infinex-multichain-apps-optimism.toml --chain-id 10 --private-key 
@@ -14,4 +14,5 @@ options.APPS_USDC = "0x0b2c639c533813f4aa9d7837caf62653d097ff85"
 # Curve Stableswap Config
 options.APPS_CRV_CURVE_STABLESWAP_FACTORY = "0x5eeE3091f747E60a045a2E715a4c71e600e31F6E" 
 source = "infinex:1.0.0@apps"
-target = "infinex:1.0.0@apps"
+target = "infinex:1.0.0staging@apps"
+tags = ["1.0.0staging"]

--- a/infinex-multichain/staging/infinex-multichain-apps-polygon.toml
+++ b/infinex-multichain/staging/infinex-multichain-apps-polygon.toml
@@ -1,5 +1,5 @@
 name = "infinex-multichain"
-version = "1.0.0"
+version = "1.0.0staging"
 preset = "apps"
 description = "Infinex App integrations"
 #   pnpm cannon build infinex-multichain/staging/infinex-multichain-apps-polygon.toml --chain-id 137 --private-key  
@@ -16,4 +16,5 @@ options.CRV_DEPLOYER = "<%= settings.DEPLOYER %>"
 options.APPS_USDC = "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359"
 options.APPS_CRV_CURVE_STABLESWAP_FACTORY = "0x1764ee18e8B3ccA4787249Ceb249356192594585" 
 source = "infinex:1.0.0@apps"
-target = "infinex:1.0.0@apps"
+target = "infinex:1.0.0staging@apps"
+tags = ["1.0.0staging"]


### PR DESCRIPTION
Changes required to publish staging packages
They were deployed without the staging tag which clashes with the production package. This adds staging to the tag.